### PR TITLE
Allow github organizations not named maptime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Starter is a simple Jekyll theme for MapTime meetups. Hosting your own meetup? S
 | markdown | No | Determines which markdown engine is used | Generally, you don't need to touch this field for your own needs. |
 | paginate | Yes | Number of posts on the front page | Starter supports pagintaion. Control the number of posts on a given page by changing this value |
 | repo | Yes | Name of the repo on GitHub | As an example, the name of the starter repo is `starter` |
+| github_org | Yes | Name of the organization or username on GitHub | Most of the time this will be 'maptime' |
 | maptime: chapter | Yes | Name of your MapTime meetup | |
 | maptime: twitter | No | Your MapTime Twitter username | |
 | maptime: disqus | No | Disqus account name | Starter optionally supports comments on posts with [Disqus](disqus.com). Create a new Disqus account for a site and fill this field with the account name. |

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ permalink: pretty
 markdown: kramdown
 paginate: 5
 repo: starter
+github_org: maptime
 maptime:
   chapter: Meetup name
   twitter: YourName

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,7 +59,7 @@
 
         <div class='hide-mobile'>
           <div class='popup-group'>
-            <a href='https://github.com/maptime/{{site.repo}}/' class='col12 space-bottom2 button'>Watch these events</a>
+            <a href='https://github.com/{{site.github_org}}/{{site.repo}}/' class='col12 space-bottom2 button'>Watch these events</a>
             <div class='popup popup-big keyline-all pad1 small round'>
               <ol class='space-bottom1'>
                 <li>1. Click the <strong>Watch these events</strong> button.</li>
@@ -75,7 +75,7 @@
           <div class='followers'></div>
           <div class='center'>
             <div class='pad0y space-bottom2'>
-              <a class='small' href='https://github.com/maptime/{{site.repo}}/watchers'>View all</a>
+              <a class='small' href='https://github.com/{{site.github_org}}/{{site.repo}}/watchers'>View all</a>
             </div>
           </div>
         </div>
@@ -89,7 +89,7 @@
 
   <footer class='fill-light pad2y'>
     <div class='limiter center small quiet'>
-     <p>This website is <a href='http://github.com/maptime/{{site.repo}}/'>open source</a> and you can improve it. Learn more about contributing <a href='https://guides.github.com/activities/forking/'>here</a>.</p>
+      <p>This website is <a href='http://github.com/{{site.github_org}}/{{site.repo}}/'>open source</a> and you can improve it. Learn more about contributing <a href='https://guides.github.com/activities/forking/'>here</a>.</p>
    </div>
   </footer>
 


### PR DESCRIPTION
This adds an additional option in `_config.yml` to specify the github organization to use when creating URLs to the repo. By default, it's 'maptime' which should just work most of the time, but if the organization is something else, a few broken links would be generated.

It would be nice if there a way to define a variable in Jekyll like 'site.repo_url' that uses the variables in config and can be referenced in the templates, but I couldn't find an easy way to do that.
