### PR TITLE
date formatting change for Safari

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -100,7 +100,7 @@
   var rsvp = document.getElementById('rsvpdate');
   var date,formatted,link;
   '{% for item in site.categories.event limit:1 %}'
-    date = '{{item.date | date:"%Y,%-m,%-d"}}';
+    date = '{{item.date | date:"%Y/%-m/%-d"}}';
     formatted = '{{item.date | date:"%A, %b %d %Y"}}';
     link = '{{item.rsvp}}';
   '{% endfor %}'


### PR DESCRIPTION
Someone just alerted me that the Maptime Chicago "upcoming events" box was showing "TBD" despite an upcoming event this week. I looked into it and, while Chrome and Firefox were working fine, Safari was indeed showing "TBD." 

![image](https://cloud.githubusercontent.com/assets/2365503/8282099/aff0cfbe-18b3-11e5-9ad1-18615bb08834.png)

After some poking around, it seems that Safari does not like dashes is a-ok with slashes. The proposed change is to go from ~~`yyyy-MM-dd`~~ `yyyy,MM,dd` to `yyyy/MM/dd`. I've made this change to the [Maptime Chicago site](http://maptime.io/chicago) and it is now working in Chrome, FF and Safari.
