### PR TITLE
Display the next immediate event

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -99,10 +99,12 @@
 <script>
   var rsvp = document.getElementById('rsvpdate');
   var date,formatted,link;
-  '{% for item in site.categories.event limit:1 %}'
-    date = '{{item.date | date:"%Y/%-m/%-d"}}';
-    formatted = '{{item.date | date:"%A, %b %d %Y"}}';
-    link = '{{item.rsvp}}';
+  '{% for item in site.categories.event %}'
+    if (new Date('{{item.date}}').getTime() >= new Date().getTime()) {
+      date = '{{item.date | date:"%Y/%-m/%-d"}}';
+      formatted = '{{item.date | date:"%A, %b %d %Y"}}';
+      link = '{{item.rsvp}}';
+    }
   '{% endfor %}'
 
   if (date && new Date().getTime() <= new Date(date).getTime() + (24 * 60 * 60 * 1000)) {


### PR DESCRIPTION
Don't add a limit to the number of events looped
so the last one is checked and condition that the
event date is in the future of today.

Fixes #22
