### PR TITLE
JS fix for date-formatting in next event

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -100,7 +100,7 @@
   var rsvp = document.getElementById('rsvpdate');
   var date,formatted,link;
   '{% for item in site.categories.event %}'
-    if (new Date('{{item.date}}').getTime() >= new Date().getTime()) {
+    if (new Date('{{item.date | date_to_xmlschema }}').getTime() >= new Date().getTime()) {
       date = '{{item.date | date:"%Y/%-m/%-d"}}';
       formatted = '{{item.date | date:"%A, %b %d %Y"}}';
       link = '{{item.rsvp}}';


### PR DESCRIPTION
Jekyll's bare `item.date` outputs a format which is not parseable by Javascript's `Date()` function and will cause this if statement to always return false on some browsers (e.g. Safari).
